### PR TITLE
Support for inner child in SwipeLayout

### DIFF
--- a/.idea/markdown-navigator/profiles_settings.xml
+++ b/.idea/markdown-navigator/profiles_settings.xml
@@ -1,0 +1,3 @@
+<component name="MarkdownNavigator.ProfileManager">
+  <settings default="" />
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -37,7 +37,7 @@
     <ConfirmationsSetting value="0" id="Add" />
     <ConfirmationsSetting value="0" id="Remove" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -37,7 +37,7 @@
     <ConfirmationsSetting value="0" id="Add" />
     <ConfirmationsSetting value="0" id="Remove" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0-alpha3'
+        classpath 'com.android.tools.build:gradle:2.3.0-beta1'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.0-alpha3'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Dec 28 10:00:20 PST 2015
+#Thu Dec 15 11:39:07 EET 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.2-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -10,7 +10,7 @@ android {
         minSdkVersion 15
         targetSdkVersion 25
         versionCode 16
-        versionName "0.4.1"
+        versionName "0.4.2"
 
     }
     buildTypes {
@@ -23,4 +23,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
+    compile 'com.android.support:support-compat:25.1.0'
 }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -10,7 +10,7 @@ android {
         minSdkVersion 15
         targetSdkVersion 25
         versionCode 16
-        versionName "0.4.3"
+        versionName "0.4.5"
 
     }
     buildTypes {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -10,7 +10,7 @@ android {
         minSdkVersion 15
         targetSdkVersion 25
         versionCode 16
-        versionName "0.4.10"
+        versionName "0.4.11"
 
     }
     buildTypes {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -10,7 +10,7 @@ android {
         minSdkVersion 15
         targetSdkVersion 25
         versionCode 16
-        versionName "0.4.7"
+        versionName "0.4.8"
 
     }
     buildTypes {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -10,7 +10,7 @@ android {
         minSdkVersion 15
         targetSdkVersion 25
         versionCode 16
-        versionName "0.4.11"
+        versionName "0.4.12"
 
     }
     buildTypes {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -10,7 +10,7 @@ android {
         minSdkVersion 15
         targetSdkVersion 25
         versionCode 16
-        versionName "0.4.0"
+        versionName "0.4.1"
 
     }
     buildTypes {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -10,7 +10,7 @@ android {
         minSdkVersion 15
         targetSdkVersion 25
         versionCode 16
-        versionName "0.4.5"
+        versionName "0.4.6"
 
     }
     buildTypes {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -10,7 +10,7 @@ android {
         minSdkVersion 15
         targetSdkVersion 25
         versionCode 16
-        versionName "0.4.6"
+        versionName "0.4.7"
 
     }
     buildTypes {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -10,7 +10,7 @@ android {
         minSdkVersion 15
         targetSdkVersion 25
         versionCode 16
-        versionName "0.4.2"
+        versionName "0.4.3"
 
     }
     buildTypes {
@@ -24,4 +24,5 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:support-compat:25.1.0'
+    provided 'com.android.support:recyclerview-v7:25.1.0'
 }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -4,13 +4,13 @@ group='com.github.alexandrius'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.0"
+    buildToolsVersion "25.0.1"
 
     defaultConfig {
         minSdkVersion 15
         targetSdkVersion 25
         versionCode 16
-        versionName "0.3.0"
+        versionName "0.4.0"
 
     }
     buildTypes {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -10,7 +10,7 @@ android {
         minSdkVersion 15
         targetSdkVersion 25
         versionCode 16
-        versionName "0.4.8"
+        versionName "0.4.9"
 
     }
     buildTypes {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -10,7 +10,7 @@ android {
         minSdkVersion 15
         targetSdkVersion 25
         versionCode 16
-        versionName "0.4.9"
+        versionName "0.4.10"
 
     }
     buildTypes {

--- a/library/src/main/java/com/alexandrius/accordionswipelayout/library/SwipeAnimation.java
+++ b/library/src/main/java/com/alexandrius/accordionswipelayout/library/SwipeAnimation.java
@@ -1,5 +1,6 @@
 package com.alexandrius.accordionswipelayout.library;
 
+import android.support.v4.view.ViewCompat;
 import android.view.View;
 import android.view.animation.Animation;
 import android.view.animation.DecelerateInterpolator;
@@ -35,9 +36,9 @@ class SwipeAnimation extends Animation {
         Utils.setViewWidth(resizeView, startWidth + (int) (((float) width - (float) startWidth) * interpolatedTime));
 
         if (left) {
-            changeXView.setX(resizeView.getWidth());
+            ViewCompat.setTranslationX(changeXView, resizeView.getWidth());
         } else {
-            changeXView.setX(-resizeView.getWidth());
+            ViewCompat.setTranslationX(changeXView, -resizeView.getWidth());
         }
 
     }

--- a/library/src/main/java/com/alexandrius/accordionswipelayout/library/SwipeLayout.java
+++ b/library/src/main/java/com/alexandrius/accordionswipelayout/library/SwipeLayout.java
@@ -27,10 +27,8 @@ import static com.alexandrius.accordionswipelayout.library.Utils.getViewWeight;
 
 
 /**
- * Created by alex on 11/18/16.
+ * @author alex, naik
  */
-
-
 public class SwipeLayout extends FrameLayout implements View.OnTouchListener, View.OnClickListener {
 
     private int layoutId;
@@ -86,20 +84,31 @@ public class SwipeLayout extends FrameLayout implements View.OnTouchListener, Vi
         setUpView();
     }
 
+    @Override
+    public void addView(View child, int index, ViewGroup.LayoutParams params) {
+        if (mainLayout != null) super.addView(child, index, params);
+        else {
+            mainLayout = child;
+            setUpView();
+        }
+    }
+
     private void setUpView() {
-        if (layoutId == -1) {
-            throw new IllegalStateException("Layout id not defined");
+        if (layoutId != -1) {
+            mainLayout = LayoutInflater.from(getContext()).inflate(layoutId, null);
+        }
+        if (mainLayout != null) {
+            compareArrays(leftColors, leftIcons);
+            compareArrays(rightColors, rightIcons);
+
+
+            addView(mainLayout);
+
+            createItemLayouts();
+            mainLayout.bringToFront();
+            mainLayout.setOnTouchListener(this);
         }
 
-        compareArrays(leftColors, leftIcons);
-        compareArrays(rightColors, rightIcons);
-
-        mainLayout = LayoutInflater.from(getContext()).inflate(layoutId, null);
-        addView(mainLayout);
-
-        createItemLayouts();
-        mainLayout.bringToFront();
-        mainLayout.setOnTouchListener(this);
     }
 
     private void compareArrays(int[] arr1, int[] arr2) {

--- a/library/src/main/java/com/alexandrius/accordionswipelayout/library/SwipeLayout.java
+++ b/library/src/main/java/com/alexandrius/accordionswipelayout/library/SwipeLayout.java
@@ -109,6 +109,12 @@ public class SwipeLayout extends FrameLayout implements View.OnTouchListener, Vi
     }
 
     @Override
+    protected void onDetachedFromWindow() {
+        setItemState(ITEM_STATE_COLLAPSED, false);
+        super.onDetachedFromWindow();
+    }
+
+    @Override
     public void addView(View child, int index, ViewGroup.LayoutParams params) {
         if (mainLayout != null) super.addView(child, index, params);
         else {

--- a/library/src/main/java/com/alexandrius/accordionswipelayout/library/SwipeLayout.java
+++ b/library/src/main/java/com/alexandrius/accordionswipelayout/library/SwipeLayout.java
@@ -635,6 +635,7 @@ public class SwipeLayout extends FrameLayout implements View.OnTouchListener, Vi
     }
 
     private void collapseOthersIfNeeded() {
+        if (!onlyOneSwipe) return;
         ViewParent parent = getParent();
         if (parent != null && parent instanceof RecyclerView) {
             RecyclerView recyclerView = (RecyclerView) parent;

--- a/library/src/main/java/com/alexandrius/accordionswipelayout/library/SwipeLayout.java
+++ b/library/src/main/java/com/alexandrius/accordionswipelayout/library/SwipeLayout.java
@@ -493,7 +493,7 @@ public class SwipeLayout extends FrameLayout implements View.OnTouchListener, Vi
                     downTime = lastTime = System.currentTimeMillis();
                     downRawX = prevRawX = event.getRawX();
 
-                    if (mainLayout.getX() == 0) {
+                    if (ViewCompat.getTranslationX(mainLayout) == 0) {
                         if (rightLinearWithoutLast != null) {
                             Utils.setViewWeight(rightLinearWithoutLast, rightViews.length - 1);
                         }
@@ -534,7 +534,7 @@ public class SwipeLayout extends FrameLayout implements View.OnTouchListener, Vi
                     int leftLayoutWidth = 0;
 
                     if (directionLeft) {
-                        float left = mainLayout.getX() - delta;
+                        float left = ViewCompat.getTranslationX(mainLayout) - delta;
 
                         if (left < -rightLayoutMaxWidth) {
                             if (!canFullSwipeFromRight) {
@@ -545,7 +545,7 @@ public class SwipeLayout extends FrameLayout implements View.OnTouchListener, Vi
                         }
 
                         if (canFullSwipeFromRight) {
-                            if (mainLayout.getX() <= -(getWidth() - fullSwipeEdgePadding)) {
+                            if (ViewCompat.getTranslationX(mainLayout) <= -(getWidth() - fullSwipeEdgePadding)) {
                                 if (getViewWeight(rightLinearWithoutLast) > 0 &&
                                         (collapseAnim == null || collapseAnim.hasEnded())) {
 
@@ -586,14 +586,14 @@ public class SwipeLayout extends FrameLayout implements View.OnTouchListener, Vi
                         }
 
                         if (leftLinear != null && left > 0) {
-                            leftLayoutWidth = (int) Math.abs(mainLayout.getX());
+                            leftLayoutWidth = (int) Math.abs(ViewCompat.getTranslationX(mainLayout));
                             LayoutParams params = (LayoutParams) leftLinear.getLayoutParams();
                             params.width = leftLayoutWidth;
                             leftLinear.setLayoutParams(params);
                         }
 
                     } else {
-                        float right = mainLayout.getX() + delta;
+                        float right = ViewCompat.getTranslationX(mainLayout) + delta;
 
                         if (right > leftLayoutMaxWidth) {
                             if (!canFullSwipeFromLeft) {
@@ -604,7 +604,7 @@ public class SwipeLayout extends FrameLayout implements View.OnTouchListener, Vi
                         }
 
                         if (canFullSwipeFromLeft) {
-                            if (mainLayout.getX() >= getWidth() - fullSwipeEdgePadding) {
+                            if (ViewCompat.getTranslationX(mainLayout) >= getWidth() - fullSwipeEdgePadding) {
                                 if (getViewWeight(leftLinearWithoutFirst) > 0 &&
                                         (collapseAnim == null || collapseAnim.hasEnded())) {
 
@@ -641,14 +641,14 @@ public class SwipeLayout extends FrameLayout implements View.OnTouchListener, Vi
                         }
 
                         if (rightLinear != null) {
-                            rightLayoutWidth = (int) Math.abs(mainLayout.getX());
+                            rightLayoutWidth = (int) Math.abs(ViewCompat.getTranslationX(mainLayout));
                             LayoutParams params = (LayoutParams) rightLinear.getLayoutParams();
                             params.width = rightLayoutWidth;
                             rightLinear.setLayoutParams(params);
                         }
                     }
 
-                    if (Math.abs(mainLayout.getX()) > itemWidth / 5) {
+                    if (Math.abs(ViewCompat.getTranslationX(mainLayout)) > itemWidth / 5) {
                         getParent().requestDisallowInterceptTouchEvent(true);
                     }
                     prevRawX = event.getRawX();
@@ -690,7 +690,7 @@ public class SwipeLayout extends FrameLayout implements View.OnTouchListener, Vi
                 View item = recyclerView.getChildAt(i);
                 if (item != this && item instanceof SwipeLayout) {
                     SwipeLayout swipeLayout = (SwipeLayout) item;
-                    if (swipeLayout.getSwipeableView().getX() != 0 && !swipeLayout.inAnimatedState()) {
+                    if (ViewCompat.getTranslationX(swipeLayout.getSwipeableView()) != 0 && !swipeLayout.inAnimatedState()) {
                         swipeLayout.setItemState(ITEM_STATE_COLLAPSED, true);
                     }
                 }
@@ -721,7 +721,7 @@ public class SwipeLayout extends FrameLayout implements View.OnTouchListener, Vi
         boolean left = false;
         int requiredWidth = 0;
 
-        if (mainLayout.getX() > 0) {
+        if (ViewCompat.getTranslationX(mainLayout) > 0) {
             animateView = leftLinear;
             left = true;
             if (leftLinear != null) {
@@ -734,7 +734,7 @@ public class SwipeLayout extends FrameLayout implements View.OnTouchListener, Vi
                 }
 
                 if (requiredWidth == leftLayoutMaxWidth && !directionLeft) {
-                    if (mainLayout.getX() >= (getWidth() - fullSwipeEdgePadding)) {
+                    if (ViewCompat.getTranslationX(mainLayout) >= (getWidth() - fullSwipeEdgePadding)) {
                         requiredWidth = getWidth();
                         invokedFromLeft = true;
                     }
@@ -743,7 +743,7 @@ public class SwipeLayout extends FrameLayout implements View.OnTouchListener, Vi
                 ViewCompat.setTranslationX(mainLayout, leftLinear.getWidth());
             }
 
-        } else if (mainLayout.getX() < 0) {
+        } else if (ViewCompat.getTranslationX(mainLayout) < 0) {
             left = false;
             animateView = rightLinear;
             if (rightLinear != null) {
@@ -757,7 +757,7 @@ public class SwipeLayout extends FrameLayout implements View.OnTouchListener, Vi
                 }
 
                 if (requiredWidth == rightLayoutMaxWidth && directionLeft) {
-                    if (mainLayout.getX() <= -(getWidth() - fullSwipeEdgePadding)) {
+                    if (ViewCompat.getTranslationX(mainLayout) <= -(getWidth() - fullSwipeEdgePadding)) {
                         requiredWidth = getWidth();
                         invokedFromLeft = false;
                     }
@@ -780,11 +780,11 @@ public class SwipeLayout extends FrameLayout implements View.OnTouchListener, Vi
             invokedFromLeft = animateView == leftLinear;
 
             if (requiredWidth == getWidth()) {
-                if (getViewWeight(layoutWithout) == 0 && getWidth() != Math.abs(mainLayout.getX()))
+                if (getViewWeight(layoutWithout) == 0 && getWidth() != Math.abs(ViewCompat.getTranslationX(mainLayout)))
                     swipeAnim.setAnimationListener(collapseListener);
                 else if (collapseAnim != null && !collapseAnim.hasEnded()) {
                     collapseAnim.setAnimationListener(collapseListener);
-                } else if (getViewWeight(layoutWithout) == 0 || getWidth() == Math.abs(mainLayout.getX())) {
+                } else if (getViewWeight(layoutWithout) == 0 || getWidth() == Math.abs(ViewCompat.getTranslationX(mainLayout))) {
                     clickBySwipe();
                 } else {
                     layoutWithout.clearAnimation();
@@ -899,7 +899,7 @@ public class SwipeLayout extends FrameLayout implements View.OnTouchListener, Vi
                 @Override
                 public void onScrollStateChanged(RecyclerView recyclerView, int newState) {
                     super.onScrollStateChanged(recyclerView, newState);
-                    if (newState == RecyclerView.SCROLL_STATE_DRAGGING && mainLayout.getX() != 0) {
+                    if (newState == RecyclerView.SCROLL_STATE_DRAGGING && ViewCompat.getTranslationX(mainLayout) != 0) {
                         setItemState(ITEM_STATE_COLLAPSED, true);
                     }
                 }
@@ -914,11 +914,11 @@ public class SwipeLayout extends FrameLayout implements View.OnTouchListener, Vi
     }
 
     public boolean isLeftExpanding() {
-        return mainLayout.getX() > 0;
+        return ViewCompat.getTranslationX(mainLayout) > 0;
     }
 
     public boolean isRightExpanding() {
-        return mainLayout.getX() < 0;
+        return ViewCompat.getTranslationX(mainLayout) < 0;
     }
 
     public boolean isExpanding() {
@@ -972,7 +972,7 @@ public class SwipeLayout extends FrameLayout implements View.OnTouchListener, Vi
                 View item = recyclerView.getChildAt(i);
                 if (item instanceof SwipeLayout) {
                     SwipeLayout swipeLayout = (SwipeLayout) item;
-                    if (swipeLayout.getSwipeableView().getX() != 0) {
+                    if (ViewCompat.getTranslationX(swipeLayout.getSwipeableView()) != 0) {
                         swipeLayout.setItemState(ITEM_STATE_COLLAPSED, animated);
                     }
                 }

--- a/library/src/main/java/com/alexandrius/accordionswipelayout/library/SwipeLayout.java
+++ b/library/src/main/java/com/alexandrius/accordionswipelayout/library/SwipeLayout.java
@@ -483,7 +483,7 @@ public class SwipeLayout extends FrameLayout implements View.OnTouchListener, Vi
 
     @Override
     public boolean onTouch(View view, MotionEvent event) {
-        if (swipeEnabled && (leftLinear != null || rightLinear != null)) {
+        if (swipeEnabled && (leftIcons != null || rightIcons != null)) {
             switch (event.getAction()) {
 
                 case MotionEvent.ACTION_DOWN:

--- a/library/src/main/java/com/alexandrius/accordionswipelayout/library/SwipeLayout.java
+++ b/library/src/main/java/com/alexandrius/accordionswipelayout/library/SwipeLayout.java
@@ -914,6 +914,23 @@ public class SwipeLayout extends FrameLayout implements View.OnTouchListener, Vi
         }
     }
 
+    public void collapseAll(boolean animated) {
+        ViewParent parent = getParent();
+        if (parent != null && parent instanceof RecyclerView) {
+            RecyclerView recyclerView = (RecyclerView) parent;
+            int count = recyclerView.getChildCount();
+            for (int i = 0; i < count; i++) {
+                View item = recyclerView.getChildAt(i);
+                if (item instanceof SwipeLayout) {
+                    SwipeLayout swipeLayout = (SwipeLayout) item;
+                    if (swipeLayout.getSwipeableView().getX() != 0) {
+                        swipeLayout.setItemState(ITEM_STATE_COLLAPSED, animated);
+                    }
+                }
+            }
+        }
+    }
+
     public interface OnSwipeItemClickListener {
         void onSwipeItemClick(boolean left, int index);
     }

--- a/library/src/main/java/com/alexandrius/accordionswipelayout/library/SwipeLayout.java
+++ b/library/src/main/java/com/alexandrius/accordionswipelayout/library/SwipeLayout.java
@@ -47,6 +47,11 @@ public class SwipeLayout extends FrameLayout implements View.OnTouchListener, Vi
     private int[] rightIcons;
     private int[] rightIconColors;
     private int[] rightTextColors;
+
+    public void setLeftColors(int[] leftColors) {
+        this.leftColors = leftColors;
+    }
+
     private int[] leftTextColors;
     private String[] leftTexts, rightTexts;
 
@@ -128,7 +133,6 @@ public class SwipeLayout extends FrameLayout implements View.OnTouchListener, Vi
             mainLayout.bringToFront();
             mainLayout.setOnTouchListener(this);
         }
-
     }
 
     private void compareArrays(int[] arr1, int[] arr2) {
@@ -139,10 +143,14 @@ public class SwipeLayout extends FrameLayout implements View.OnTouchListener, Vi
         }
     }
 
+    public void invalidateSwipeItems() {
+        createItemLayouts();
+    }
 
     private void createItemLayouts() {
         if (rightIcons != null) {
             rightLayoutMaxWidth = itemWidth * rightIcons.length;
+            if (rightLinear != null) removeView(rightLinear);
             rightLinear = createLinearLayout(Gravity.RIGHT);
             rightLinearWithoutLast = createLinearLayout(Gravity.RIGHT);
             rightLinearWithoutLast.setLayoutParams(new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.MATCH_PARENT, rightIcons.length - 1));
@@ -154,6 +162,7 @@ public class SwipeLayout extends FrameLayout implements View.OnTouchListener, Vi
 
         if (leftIcons != null) {
             leftLayoutMaxWidth = itemWidth * leftIcons.length;
+            if (leftLinear != null) removeView(leftLinear);
             leftLinear = createLinearLayout(Gravity.LEFT);
             leftLinearWithoutFirst = createLinearLayout(Gravity.LEFT);
             leftLinearWithoutFirst.setLayoutParams(new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.MATCH_PARENT, leftIcons.length - 1));
@@ -344,6 +353,42 @@ public class SwipeLayout extends FrameLayout implements View.OnTouchListener, Vi
         if (rightTextColorRes != NO_ID) rightTextColors = res.getIntArray(rightTextColorRes);
         if (leftIconColorsRes != NO_ID) leftIconColors = res.getIntArray(leftIconColorsRes);
         if (rightIconColorsRes != NO_ID) rightIconColors = res.getIntArray(rightIconColorsRes);
+    }
+
+    public void setLeftIcons(int[] leftIcons) {
+        this.leftIcons = leftIcons;
+    }
+
+    public void setLeftIconColors(int[] leftIconColors) {
+        this.leftIconColors = leftIconColors;
+    }
+
+    public void setRightColors(int[] rightColors) {
+        this.rightColors = rightColors;
+    }
+
+    public void setRightIcons(int[] rightIcons) {
+        this.rightIcons = rightIcons;
+    }
+
+    public void setRightIconColors(int[] rightIconColors) {
+        this.rightIconColors = rightIconColors;
+    }
+
+    public void setRightTextColors(int[] rightTextColors) {
+        this.rightTextColors = rightTextColors;
+    }
+
+    public void setLeftTextColors(int[] leftTextColors) {
+        this.leftTextColors = leftTextColors;
+    }
+
+    public void setLeftTexts(String[] leftTexts) {
+        this.leftTexts = leftTexts;
+    }
+
+    public void setRightTexts(String[] rightTexts) {
+        this.rightTexts = rightTexts;
     }
 
     private int[] fillDrawables(TypedArray ta) {

--- a/library/src/main/java/com/alexandrius/accordionswipelayout/library/SwipeLayout.java
+++ b/library/src/main/java/com/alexandrius/accordionswipelayout/library/SwipeLayout.java
@@ -483,7 +483,7 @@ public class SwipeLayout extends FrameLayout implements View.OnTouchListener, Vi
 
     @Override
     public boolean onTouch(View view, MotionEvent event) {
-        if (swipeEnabled) {
+        if (swipeEnabled && (leftLinear != null || rightLinear != null)) {
             switch (event.getAction()) {
 
                 case MotionEvent.ACTION_DOWN:

--- a/library/src/main/java/com/alexandrius/accordionswipelayout/library/SwipeLayout.java
+++ b/library/src/main/java/com/alexandrius/accordionswipelayout/library/SwipeLayout.java
@@ -940,20 +940,24 @@ public class SwipeLayout extends FrameLayout implements View.OnTouchListener, Vi
     @Override
     public void onClick(View view) {
         if (onSwipeItemClickListener != null) {
-            for (int i = 0; i < leftViews.length; i++) {
-                View v = leftViews[i];
-                if (v == view) {
-                    if (leftViews.length == 1 || getViewWeight(leftLinearWithoutFirst) > 0)
-                        onSwipeItemClickListener.onSwipeItemClick(true, i);
-                    return;
+            if (leftViews != null) {
+                for (int i = 0; i < leftViews.length; i++) {
+                    View v = leftViews[i];
+                    if (v == view) {
+                        if (leftViews.length == 1 || getViewWeight(leftLinearWithoutFirst) > 0)
+                            onSwipeItemClickListener.onSwipeItemClick(true, i);
+                        return;
+                    }
                 }
             }
-            for (int i = 0; i < rightViews.length; i++) {
-                View v = rightViews[i];
-                if (v == view) {
-                    if (rightViews.length == 1 || getViewWeight(rightLinearWithoutLast) > 0)
-                        onSwipeItemClickListener.onSwipeItemClick(false, i);
-                    break;
+            if (rightViews != null) {
+                for (int i = 0; i < rightViews.length; i++) {
+                    View v = rightViews[i];
+                    if (v == view) {
+                        if (rightViews.length == 1 || getViewWeight(rightLinearWithoutLast) > 0)
+                            onSwipeItemClickListener.onSwipeItemClick(false, i);
+                        break;
+                    }
                 }
             }
         }

--- a/library/src/main/java/com/alexandrius/accordionswipelayout/library/SwipeLayout.java
+++ b/library/src/main/java/com/alexandrius/accordionswipelayout/library/SwipeLayout.java
@@ -74,8 +74,6 @@ public class SwipeLayout extends FrameLayout implements View.OnTouchListener, Vi
     public SwipeLayout(Context context, AttributeSet attrs) {
         super(context, attrs);
 
-        if (isInEditMode()) return;
-
         fullSwipeEdgePadding = getResources().getDimensionPixelSize(R.dimen.full_swipe_edge_padding);
 
         if (attrs != null) {
@@ -301,13 +299,13 @@ public class SwipeLayout extends FrameLayout implements View.OnTouchListener, Vi
         if (rightColorsRes != -1)
             rightColors = getResources().getIntArray(rightColorsRes);
 
-        if (rightIconsRes != -1)
+        if (rightIconsRes != -1 && !isInEditMode())
             rightIcons = fillDrawables(getResources().obtainTypedArray(rightIconsRes));
 
         if (leftColorsRes != -1)
             leftColors = getResources().getIntArray(leftColorsRes);
 
-        if (leftIconsRes != -1)
+        if (leftIconsRes != -1 && !isInEditMode())
             leftIcons = fillDrawables(getResources().obtainTypedArray(leftIconsRes));
 
         if (leftTextRes != -1)

--- a/library/src/main/java/com/alexandrius/accordionswipelayout/library/SwipeLayout.java
+++ b/library/src/main/java/com/alexandrius/accordionswipelayout/library/SwipeLayout.java
@@ -9,6 +9,7 @@ import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.os.Handler;
 import android.support.v4.content.ContextCompat;
+import android.support.v4.view.ViewCompat;
 import android.support.v7.widget.RecyclerView;
 import android.util.AttributeSet;
 import android.util.Log;
@@ -574,7 +575,7 @@ public class SwipeLayout extends FrameLayout implements View.OnTouchListener, Vi
                             }
                         }
 
-                        mainLayout.setX(left);
+                        ViewCompat.setTranslationX(mainLayout, left);
 
                         if (rightLinear != null) {
                             rightLayoutWidth = (int) Math.abs(left);
@@ -630,7 +631,7 @@ public class SwipeLayout extends FrameLayout implements View.OnTouchListener, Vi
                             }
                         }
 
-                        mainLayout.setX(right);
+                        ViewCompat.setTranslationX(mainLayout, right);
 
                         if (leftLinear != null && right > 0) {
                             leftLayoutWidth = (int) Math.abs(right);
@@ -739,7 +740,7 @@ public class SwipeLayout extends FrameLayout implements View.OnTouchListener, Vi
                     }
                 }
 
-                mainLayout.setX(leftLinear.getWidth());
+                ViewCompat.setTranslationX(mainLayout, leftLinear.getWidth());
             }
 
         } else if (mainLayout.getX() < 0) {
@@ -762,7 +763,7 @@ public class SwipeLayout extends FrameLayout implements View.OnTouchListener, Vi
                     }
                 }
 
-                mainLayout.setX(-rightLinear.getWidth());
+                ViewCompat.setTranslationX(mainLayout, -rightLinear.getWidth());
             }
         }
         long duration = (long) (100 * speed);
@@ -819,7 +820,7 @@ public class SwipeLayout extends FrameLayout implements View.OnTouchListener, Vi
                 SwipeAnimation swipeAnim = new SwipeAnimation(leftLinear, 0, mainLayout, true);
                 leftLinear.startAnimation(swipeAnim);
             } else {
-                mainLayout.setX(0);
+                ViewCompat.setTranslationX(mainLayout, 0);
                 ViewGroup.LayoutParams params = leftLinear.getLayoutParams();
                 params.width = 0;
                 leftLinear.setLayoutParams(params);
@@ -831,7 +832,7 @@ public class SwipeLayout extends FrameLayout implements View.OnTouchListener, Vi
                 SwipeAnimation swipeAnim = new SwipeAnimation(rightLinear, 0, mainLayout, false);
                 rightLinear.startAnimation(swipeAnim);
             } else {
-                mainLayout.setX(0);
+                ViewCompat.setTranslationX(mainLayout, 0);
                 ViewGroup.LayoutParams params = rightLinear.getLayoutParams();
                 params.width = 0;
                 rightLinear.setLayoutParams(params);
@@ -850,7 +851,7 @@ public class SwipeLayout extends FrameLayout implements View.OnTouchListener, Vi
                     SwipeAnimation swipeAnim = new SwipeAnimation(leftLinear, requiredWidthLeft, mainLayout, true);
                     leftLinear.startAnimation(swipeAnim);
                 } else {
-                    mainLayout.setX(requiredWidthLeft);
+                    ViewCompat.setTranslationX(mainLayout, requiredWidthLeft);
                     ViewGroup.LayoutParams params = leftLinear.getLayoutParams();
                     params.width = requiredWidthLeft;
                     leftLinear.setLayoutParams(params);
@@ -862,7 +863,7 @@ public class SwipeLayout extends FrameLayout implements View.OnTouchListener, Vi
                     SwipeAnimation swipeAnim = new SwipeAnimation(rightLinear, requiredWidthRight, mainLayout, false);
                     rightLinear.startAnimation(swipeAnim);
                 } else {
-                    mainLayout.setX(-requiredWidthRight);
+                    ViewCompat.setTranslationX(mainLayout, -requiredWidthRight);
                     ViewGroup.LayoutParams params = rightLinear.getLayoutParams();
                     params.width = requiredWidthRight;
                     rightLinear.setLayoutParams(params);
@@ -935,7 +936,6 @@ public class SwipeLayout extends FrameLayout implements View.OnTouchListener, Vi
     public boolean isExpanded() {
         return isLeftExpanded() || isRightExpanded();
     }
-
 
     @Override
     public void onClick(View view) {

--- a/library/src/main/java/com/alexandrius/accordionswipelayout/library/ViewUtils.java
+++ b/library/src/main/java/com/alexandrius/accordionswipelayout/library/ViewUtils.java
@@ -1,0 +1,16 @@
+package com.alexandrius.accordionswipelayout.library;
+
+import android.graphics.drawable.Drawable;
+import android.support.v4.graphics.drawable.DrawableCompat;
+
+/**
+ * @author naik
+ */
+public class ViewUtils {
+
+    public static Drawable setTint(Drawable drawable, int color) {
+        drawable = DrawableCompat.wrap(drawable);
+        DrawableCompat.setTint(drawable, color);
+        return drawable.mutate();
+    }
+}

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -20,6 +20,8 @@
         <attr name="customFont" format="string" />
         <attr name="canFullSwipeFromLeft" format="boolean"/>
         <attr name="canFullSwipeFromRight" format="boolean"/>
+        <attr name="autoHideSwipe" format="boolean" />
+        <attr name="onlyOneSwipe" format="boolean" />
 
     </declare-styleable>
 

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -6,6 +6,8 @@
         <attr name="leftItemIcons" format="reference" />
         <attr name="rightItemColors" format="reference" />
         <attr name="leftTextColors" format="reference" />
+        <attr name="leftIconColors" format="reference" />
+        <attr name="rightIconColors" format="reference" />
         <attr name="rightTextColors" format="reference" />
         <attr name="rightItemIcons" format="reference" />
         <attr name="swipeItemWidth" format="dimension" />

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -20,8 +20,8 @@ android {
 
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile 'com.android.support:appcompat-v7:25.0.1'
-    compile "com.android.support:recyclerview-v7:25.0.1"
+    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile "com.android.support:recyclerview-v7:25.1.0"
 //    compile 'com.github.alexandrius:accordion-swipe-layout:0.2.6'
     compile project(':library')
 }

--- a/sample/src/main/res/drawable/ic_reload_colored.xml
+++ b/sample/src/main/res/drawable/ic_reload_colored.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<bitmap xmlns:android="http://schemas.android.com/apk/res/android"
-    android:src="@mipmap/ic_reload"
-    android:tint="@color/textColor1">
-
-</bitmap>

--- a/sample/src/main/res/layout/recycler_view_item.xml
+++ b/sample/src/main/res/layout/recycler_view_item.xml
@@ -10,6 +10,7 @@
     app:leftItemColors="@array/leftColors"
     app:leftItemIcons="@array/leftDrawables"
     app:rightItemColors="@array/rightColors"
+    app:rightIconColors="@array/rightDrawableColors"
     app:rightItemIcons="@array/rightDrawables"
     app:rightStrings="@array/rightTexts"
     app:rightTextColors="@array/rightTextColors"

--- a/sample/src/main/res/layout/recycler_view_item.xml
+++ b/sample/src/main/res/layout/recycler_view_item.xml
@@ -1,17 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.alexandrius.accordionswipelayout.library.SwipeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<com.alexandrius.accordionswipelayout.library.SwipeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/swipe_layout"
     android:layout_width="match_parent"
     android:layout_height="80dp"
+    app:canFullSwipeFromRight="true"
     app:iconSize="@dimen/icon_size"
-    app:layout="@layout/sample_item"
     app:leftItemColors="@array/leftColors"
     app:leftItemIcons="@array/leftDrawables"
     app:rightItemColors="@array/rightColors"
     app:rightItemIcons="@array/rightDrawables"
     app:rightStrings="@array/rightTexts"
-    app:canFullSwipeFromRight="true"
     app:rightTextColors="@array/rightTextColors"
     app:swipeItemWidth="@dimen/swipe_item_width"
-    app:textSize="@dimen/text_size" />
+    app:textSize="@dimen/text_size">
+
+    <include layout="@layout/sample_item"/>
+
+</com.alexandrius.accordionswipelayout.library.SwipeLayout>

--- a/sample/src/main/res/values/array.xml
+++ b/sample/src/main/res/values/array.xml
@@ -19,15 +19,20 @@
     </integer-array>
 
     <integer-array name="rightDrawables">
-        <item>@drawable/ic_reload_colored</item>
+        <item>@mipmap/ic_reload</item>
         <item>@mipmap/ic_settings</item>
         <item>@mipmap/ic_trash</item>
+    </integer-array>
+
+    <integer-array name="rightDrawableColors">
+        <item>@color/textColor1</item>
+        <item>@color/textColor2</item>
+        <item>@color/textColor3</item>
     </integer-array>
 
     <integer-array name="leftDrawables">
         <item>@mipmap/ic_reload</item>
     </integer-array>
-
 
     <string-array name="rightTexts">
         <item>@string/reload</item>


### PR DESCRIPTION
``` xml
<?xml version="1.0" encoding="utf-8"?>
<com.alexandrius.accordionswipelayout.library.SwipeLayout
    xmlns:android="http://schemas.android.com/apk/res/android"
    xmlns:app="http://schemas.android.com/apk/res-auto"
    android:id="@+id/swipe_layout"
    android:layout_width="match_parent"
    android:layout_height="80dp"
    app:canFullSwipeFromRight="true"
    app:iconSize="@dimen/icon_size"
    app:leftItemColors="@array/leftColors"
    app:leftItemIcons="@array/leftDrawables"
    app:rightItemColors="@array/rightColors"
    app:rightItemIcons="@array/rightDrawables"
    app:rightStrings="@array/rightTexts"
    app:rightTextColors="@array/rightTextColors"
    app:swipeItemWidth="@dimen/swipe_item_width"
    app:textSize="@dimen/text_size">

    <include layout="@layout/sample_item"/>

</com.alexandrius.accordionswipelayout.library.SwipeLayout>
```

First child used as _item view_ if no `app:layout` attribute found.